### PR TITLE
fix "cannot import name Bootstrap3Layout" bug

### DIFF
--- a/uliweb_peafowl/admin_models_config/views.py
+++ b/uliweb_peafowl/admin_models_config/views.py
@@ -67,10 +67,10 @@ class AdminModelsConfigView(object):
                   'basemodel', 'has_extension', 'extension_model']
 
         def post_created_form(fcls, model):
-            from uliweb_peafowl.layout.form_helper import Bootstrap3Layout
+            from uliweb_peafowl.layout.form_helper import Bootstrap3VLayout
             from uliweb.form.widgets import Button
 
-            fcls.layout_class = Bootstrap3Layout
+            fcls.layout_class = Bootstrap3VLayout
             fcls.form_buttons = [
                 str(Button(value=_('Save'), _class="btn btn-primary btn-sm",
                     name="submit", type="submit")),


### PR DESCRIPTION
![040x wo0 83la0 fykps o](https://cloud.githubusercontent.com/assets/3524513/7443854/dcf5fc18-f19a-11e4-8186-b6a0f7654b35.png)
按照demo中的例子搭建，在Data Models 页面点击add会出现找不到Bootstrap3Layout，查看form_helper发现已改为Bootstrap3VLayout
